### PR TITLE
Orden en el calendar por defecto. Fecha en negita.

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -7,7 +7,7 @@ export function renderCalendar(matches, next_days=50) {
   const next_matches = matches.filter(match => match.date_obj >= today && match.date_obj <= next_week);
 
   const events = next_matches.map(match => ({
-    title: match.league,
+    title: match.league + `${match.team1.includes(FILTER_ONLY) ? ` (local)` : ``}`,
     description: `${match.team1} vs ${match.team2}`,
     // print Orange the team name if that team contains "RAXOI"
     htmlDescription: `${match.team1.includes(FILTER_ONLY) ? `<span style="color: orange;">${match.team1}</span>` : match.team1} vs ${match.team2.includes(FILTER_ONLY) ? `<span style="color: orange;">${match.team2}</span>` : match.team2}`,
@@ -23,7 +23,7 @@ export function renderCalendar(matches, next_days=50) {
     initialView: 'listWeek',
     firstDay: 1,
     events: events,
-    eventOrder: eventOrder, // Add this line to set the event order
+    // eventOrder: eventOrder, // Add this line to set the event order
     eventTimeFormat: { // use 24-hour format
       hour: '2-digit',
       minute: '2-digit',

--- a/style/style.css
+++ b/style/style.css
@@ -51,6 +51,7 @@ h2 {
     background-color: #ffdab3;
     /* Add blinking animation to the first cell of rows with the "match-soon" class */
     /* animation: blink 1s infinite; */
+    font-weight: bold;
 }
 
 @keyframes blink {


### PR DESCRIPTION
La fecha en negrita en el listado de partidos es más fácil de leer.

El orden en el calendario de google creo que está mejor el orden por defecto, porque aparecen los partidos ordenados por "hora".  La ordenación por categoría resulta más confusa en mi opinión.